### PR TITLE
Add predicate-driven cancel commands with protected order index

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Launch `z` to drop into an interactive shell that accepts fast trading mnemonics
 
 - Interactive shell (`z>`) with one-liners and a help summary
 - Dry-run mode for safe practice; live mode for real orders
-- Market/limit/SL/SL-M entries, position close, selective cancel
+- Market/limit/SL/SL-M entries, position close, selective cancel (ID/all/predicate/ladder/nonessential)
 - Execution helpers: price laddering (`scale`) and limit chasing (`chase`)
 - Blotters: open orders, positions with live marks, local history
 - Config persistence under `~/.config/zerodhacli/config.json`
@@ -50,6 +50,12 @@ Config keys and defaults:
 - `autoslice`: `false` (let Kite auto-slice large orders when supported)
 - `throttle_warning_threshold`: `0.8` (warn near rate limits)
 
+A lightweight shadow index of acknowledged orders lives beside the config as
+`~/.config/zerodhacli/state.db`. It stores roles/strategy tags/protected flags so
+`cancel where`, `cancel ladder`, and `cancel nonessential` can skip stop-loss /
+hedge legs by default. The index is updated on each placement/cancel and is safe
+to delete if you need to reset metadata.
+
 Example:
 
 ```json
@@ -72,7 +78,7 @@ Interactive usage and command examples are documented in `docs/USAGE.md`. Highli
 - Entries: `buy SYMBOL QTY [@PRICE]`, `sell SYMBOL QTY [@PRICE]`
 - Stop-loss: `sl SYMBOL QTY TRIGGER [PRICE]` (omit PRICE for SL-M)
 - Close: `close SYMBOL` (accepts `EXCHANGE:SYMBOL` or `SYMBOL`)
-- Cancel: `cancel ORDERID` or `cancel all`
+- Cancel: `cancel ORDERID`, `cancel all`, predicate cancel (`cancel where`), ladder drain (`cancel ladder SYMBOL`), or clear loose legs (`cancel nonessential`)
 - Ladder: `scale SYMBOL QTY START END COUNT`
 - Chase: `chase SYMBOL QTY PRICE MAX_MOVES TICK`
 - Blotters: `orders`, `pos`, `history [N]`, plus `help`, `quit`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -24,6 +24,9 @@ that shell or directly after the `z` binary.
 | `sl SYMBOL QTY TRIGGER [PRICE]` | Stop-loss; skip PRICE for SL-M | `z sl HDFCBANK 1 1490 1491` |
 | `close SYMBOL` | Flatten open position; accepts `NSE:HDFCBANK` or `HDFCBANK` | `z close BANKNIFTY24OCTFUT` |
 | `cancel ORDERID` / `cancel all` | Cancel single order or everything open | `z cancel DRY-123abc` |
+| `cancel where "expr"` | Predicate cancel using `age`, `role`, `group`, `symbol`, `status`, `protected`, `strategy_id` | `z cancel where "symbol == 'INFY' and age > 30"` |
+| `cancel ladder SYMBOL` | Nuke ladders/buckets for a symbol (skips protected legs unless forced) | `z cancel ladder INFY` |
+| `cancel nonessential [--strategy ID]` | Cancel all non-protected legs, optionally scoped to a strategy | `z cancel nonessential --strategy swing` |
 
 ## Execution algos
 
@@ -59,6 +62,12 @@ hash changes or credentials are missing in live mode, the heading prints a
 the unrealised PnL calculated from the position's average price, and the day's
 running PnL from Zerodha. Totals are summarised at the bottom so you can glance
 at per-instrument and portfolio PnL without leaving the shell.
+
+A local SQLite index (`~/.config/zerodhacli/state.db`) keeps track of order
+roles/groups/strategy tags. Protected roles (stop-loss/take-profit/hedge) are
+flagged so `cancel where`, `cancel ladder`, and `cancel nonessential` ignore
+them by default. To force-cancel protected legs you must provide both
+`--include-protected` and `--confirm` on the relevant command.
 
 Auto-slicing is disabled by default; enable it by setting `"autoslice": true`
 in `~/.config/zerodhacli/config.json` if your instrument supports it.

--- a/src/zerodhacli/core/config.py
+++ b/src/zerodhacli/core/config.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 CONFIG_DIR = Path(os.environ.get("ZERODHACLI_CONFIG_DIR", Path.home() / ".config" / "zerodhacli"))
 CONFIG_FILE = CONFIG_DIR / "config.json"
+STATE_DB = CONFIG_DIR / "state.db"
 
 
 @dataclass(slots=True)

--- a/src/zerodhacli/services/order_index.py
+++ b/src/zerodhacli/services/order_index.py
@@ -1,0 +1,142 @@
+"""SQLite-backed shadow index for order metadata."""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+from ..core.config import STATE_DB
+
+
+@dataclass(slots=True)
+class OrderMetadata:
+    """Metadata captured for each acknowledged order."""
+
+    order_id: str
+    role: Optional[str] = None
+    group: Optional[str] = None
+    strategy_id: Optional[str] = None
+    protected: bool = False
+    symbol: Optional[str] = None
+    created_at: Optional[datetime] = None
+
+    @property
+    def age_seconds(self) -> Optional[float]:
+        if self.created_at is None:
+            return None
+        now = datetime.now(timezone.utc)
+        reference = self.created_at if self.created_at.tzinfo else self.created_at.replace(tzinfo=timezone.utc)
+        return (now - reference).total_seconds()
+
+
+class OrderIndex:
+    """Persist metadata for orders to enable predicate cancels."""
+
+    def __init__(self, path: Optional[Path] = None) -> None:
+        self._path = str(path or STATE_DB)
+        self._connection = sqlite3.connect(self._path, check_same_thread=False, detect_types=sqlite3.PARSE_DECLTYPES)
+        self._connection.row_factory = sqlite3.Row
+        self._ensure_schema()
+
+    def _ensure_schema(self) -> None:
+        with self._connection:
+            self._connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS order_index (
+                    order_id TEXT PRIMARY KEY,
+                    role TEXT,
+                    group_id TEXT,
+                    strategy_id TEXT,
+                    protected INTEGER NOT NULL DEFAULT 0,
+                    symbol TEXT,
+                    created_at TEXT NOT NULL
+                )
+                """
+            )
+
+    def close(self) -> None:
+        self._connection.close()
+
+    def record(
+        self,
+        order_id: str,
+        *,
+        role: Optional[str] = None,
+        group: Optional[str] = None,
+        strategy_id: Optional[str] = None,
+        protected: bool = False,
+        symbol: Optional[str] = None,
+        created_at: Optional[datetime] = None,
+    ) -> None:
+        timestamp = (created_at or datetime.now(timezone.utc)).isoformat()
+        with self._connection:
+            self._connection.execute(
+                """
+                INSERT INTO order_index (order_id, role, group_id, strategy_id, protected, symbol, created_at)
+                VALUES (:order_id, :role, :group_id, :strategy_id, :protected, :symbol, :created_at)
+                ON CONFLICT(order_id) DO UPDATE SET
+                    role=excluded.role,
+                    group_id=excluded.group_id,
+                    strategy_id=excluded.strategy_id,
+                    protected=excluded.protected,
+                    symbol=excluded.symbol,
+                    created_at=excluded.created_at
+                """,
+                {
+                    "order_id": order_id,
+                    "role": role,
+                    "group_id": group,
+                    "strategy_id": strategy_id,
+                    "protected": 1 if protected else 0,
+                    "symbol": symbol,
+                    "created_at": timestamp,
+                },
+            )
+
+    def bulk_fetch(self, order_ids: Iterable[str]) -> Dict[str, OrderMetadata]:
+        ids = list(order_ids)
+        if not ids:
+            return {}
+        placeholders = ",".join("?" for _ in ids)
+        cursor = self._connection.execute(
+            f"SELECT * FROM order_index WHERE order_id IN ({placeholders})",
+            ids,
+        )
+        mapping: Dict[str, OrderMetadata] = {}
+        for row in cursor.fetchall():
+            created_at_raw = row["created_at"]
+            created_at = None
+            if isinstance(created_at_raw, datetime):
+                created_at = created_at_raw
+            elif isinstance(created_at_raw, str):
+                try:
+                    created_at = datetime.fromisoformat(created_at_raw)
+                except ValueError:
+                    created_at = None
+            mapping[row["order_id"]] = OrderMetadata(
+                order_id=row["order_id"],
+                role=row["role"],
+                group=row["group_id"],
+                strategy_id=row["strategy_id"],
+                protected=bool(row["protected"]),
+                symbol=row["symbol"],
+                created_at=created_at,
+            )
+        return mapping
+
+    def purge(self, order_ids: Iterable[str]) -> None:
+        ids = list(order_ids)
+        if not ids:
+            return
+        placeholders = ",".join("?" for _ in ids)
+        with self._connection:
+            self._connection.execute(
+                f"DELETE FROM order_index WHERE order_id IN ({placeholders})",
+                ids,
+            )
+
+
+__all__ = ["OrderIndex", "OrderMetadata"]


### PR DESCRIPTION
## Summary
- add an on-disk order index for tracking role/group/strategy metadata and wire it into the service container and router
- expand the CLI with predicate/ladder/nonessential cancel flows that honour protected legs and evaluate safe expressions
- document the new cancel tooling and update tests to cover metadata persistence

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68df9645b8708322a4633ac34487e49e